### PR TITLE
switch github-pages container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This is the repository for the nabla-containers.github.io blog.
 The page can be simulated with the following container:
 
 ```
-docker run -t --rm -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages
+docker run --rm -v $PWD:/site -p 4000:4000 andredumas/github-pages serve --watch
 ```


### PR DESCRIPTION
On my mac, the specified github-pages container for local testing doesn't work.  This one does, @lumjjb can you check that it works for you too?