### PR TITLE
Fix typos and trailing whitespace

### DIFF
--- a/_posts/2018-12-05-exploit-model.md
+++ b/_posts/2018-12-05-exploit-model.md
@@ -27,11 +27,11 @@ In general, with attacker capabilities to leak and arbitrary write, it is almost
 
 Other examples of these are unreliable read/writes (does not always happen, depending on some randomness of the program), or read/writes that can include randomness or proximity. However, these type of limited capabilities can be overcome with additional work - performing actions more than once (rowhammer) or using certain techniques (i.e. heap spraying, nop slides).
 
-## Explaining "Prvilege Escalation in gVisor"
+## Explaining "Privilege Escalation in gVisor"
 
 ```
 +--------+ +--------+   +---------+
-|  p1a   | |  p1a   |   |   p2a   |                      APP
+|  p1a   | |  p1b   |   |   p2a   |                      APP
 +--------+ +--------+   +---------+
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |            gVisor
@@ -50,8 +50,8 @@ The exploit assumes the following attacker capabilities: Code exec in an applica
 ```
 +--------+ +--------+   +---------+
 |  p1a   | |  p1b   |   |   p2a   |                      APP
-| (code) | |        |   |         |                      
-| (exec) | |        |   |         |                      
+| (code) | |        |   |         |
+| (exec) | |        |   |         |
 +--------+ +--------+   +---------+
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |            gVisor
@@ -69,12 +69,12 @@ The exploit abuses the `shmctl` bug to acheive the attacker capabilities to perf
     |          V
 +--------+ +--------+   +---------+
 |  p1a   | |  p1b   |   |   p2a   |                      APP
-| (code) | |(random)|   |         |                      
-| (exec) | |( write)|   |         |                      
+| (code) | |(random)|   |         |
+| (exec) | |( write)|   |         |
 +--------+ +--------+   +---------+
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |            gVisor
-|  (limited write)  |   |                   |            
+|  (limited write)  |   |                   |
 +-------------------+   +-------------------+
 +--------------------------------------------------+
 |                    kernel                        |     KERNEL
@@ -130,7 +130,7 @@ So assuming that we've obtained code exec in gVisor, what is our exposure? We lo
 <<< 300 syscalls  >>>   <<< 300 syscalls  >>>
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |         USERSPACE KERNEL
-|   (code exec)     |   |                   |            
+|   (code exec)     |   |                   |
 +-------------------+   +-------------------+
 <<<  83 syscalls  >>>   <<<  83 syscalls  >>>    <--- Attack surface
 +--------------------------------------------------+
@@ -155,7 +155,7 @@ However, in terms of (2) Guarding of host kernel calls, we currently do not forc
 |  p1a   |              |   p2a   |                   APP
 +-------------------+   +-------------------+
 |    nabla LibOS    |   |   nabla LibOS     |         USERSPACE KERNEL
-|    (code exec)    |   |                   |            
+|    (code exec)    |   |                   |
 +-------------------+   +-------------------+
 <<<   7 syscalls  >>>   <<<   7 syscalls  >>>    <--- Attack surface
 +--------------------------------------------------+
@@ -169,13 +169,13 @@ To summarize, here's a side-by-side comparison of the models:
       gVisor                   NABLA
       ------                   -----
 
-+--------+              
++--------+
 |  p1a   |                                            APP
 +--------+              +---------+
 <<< 300 syscalls  >>>   |   p2a   |              <--- Guard Calls (2)
 +-------------------+   +-------------------+
 |      gVisor       |   |   nabla LibOS     |         USERSPACE KERNEL
-|   (code exec)     |   |                   |            
+|   (code exec)     |   |                   |
 +-------------------+   +-------------------+
 <<<  83 syscalls  >>>   <<<   7 syscalls  >>>    <--- Atk. surface (1)
 +--------------------------------------------------+
@@ -209,7 +209,7 @@ The vulnerability is detailed on STALKR's blog post ["Golang data races to break
 
 ## What's next?
 
-In conclusion, we've observed that gVisor and Nabla draw several similarities in the threat model, and yet they focus on different methods of providing security - maximize attack surface reduction (Nabla) vs guarding host syscalls and a safer implementation (gVisor). 
+In conclusion, we've observed that gVisor and Nabla draw several similarities in the threat model, and yet they focus on different methods of providing security - maximize attack surface reduction (Nabla) vs guarding host syscalls and a safer implementation (gVisor).
 We would like to find ways to quantify the two additional security ideas from gvisor (guarding host syscalls and safer implementations), to include in our isolation metric.
 
 As discussed, we think the guarding of host kernel calls provides security value add for Nabla, but we hypothesize that it may not add much to the security of the very limited attack surface. However, if it is possible to do this with little trade-off, it would be something that we would like to do in the future!

--- a/_posts/2018-12-12-exploit-model.md
+++ b/_posts/2018-12-12-exploit-model.md
@@ -27,11 +27,11 @@ In general, with attacker capabilities to leak and arbitrary write, it is almost
 
 Other examples of these are unreliable read/writes (does not always happen, depending on some randomness of the program), or read/writes that can include randomness or proximity. However, these type of limited capabilities can be overcome with additional work - performing actions more than once (rowhammer) or using certain techniques (i.e. heap spraying, nop slides).
 
-## Explaining "Prvilege Escalation in gVisor"
+## Explaining "Privilege Escalation in gVisor"
 
 ```
 +--------+ +--------+   +---------+
-|  p1a   | |  p1a   |   |   p2a   |                      APP
+|  p1a   | |  p1b   |   |   p2a   |                      APP
 +--------+ +--------+   +---------+
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |            gVisor
@@ -50,8 +50,8 @@ The exploit assumes the following attacker capabilities: Code exec in an applica
 ```
 +--------+ +--------+   +---------+
 |  p1a   | |  p1b   |   |   p2a   |                      APP
-| (code) | |        |   |         |                      
-| (exec) | |        |   |         |                      
+| (code) | |        |   |         |
+| (exec) | |        |   |         |
 +--------+ +--------+   +---------+
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |            gVisor
@@ -69,12 +69,12 @@ The exploit abuses the `shmctl` bug to acheive the attacker capabilities to perf
     |          V
 +--------+ +--------+   +---------+
 |  p1a   | |  p1b   |   |   p2a   |                      APP
-| (code) | |(random)|   |         |                      
-| (exec) | |( write)|   |         |                      
+| (code) | |(random)|   |         |
+| (exec) | |( write)|   |         |
 +--------+ +--------+   +---------+
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |            gVisor
-|  (limited write)  |   |                   |            
+|  (limited write)  |   |                   |
 +-------------------+   +-------------------+
 +--------------------------------------------------+
 |                    kernel                        |     KERNEL
@@ -130,7 +130,7 @@ So assuming that we've obtained code exec in gVisor, what is our exposure? We lo
 <<< 300 syscalls  >>>   <<< 300 syscalls  >>>
 +-------------------+   +-------------------+
 |      gVisor       |   |      gVisor       |         USERSPACE KERNEL
-|   (code exec)     |   |                   |            
+|   (code exec)     |   |                   |
 +-------------------+   +-------------------+
 <<<  83 syscalls  >>>   <<<  83 syscalls  >>>    <--- Attack surface
 +--------------------------------------------------+
@@ -155,7 +155,7 @@ However, in terms of (2) Guarding of host kernel calls, we currently do not forc
 |  p1a   |              |   p2a   |                   APP
 +-------------------+   +-------------------+
 |    nabla LibOS    |   |   nabla LibOS     |         USERSPACE KERNEL
-|    (code exec)    |   |                   |            
+|    (code exec)    |   |                   |
 +-------------------+   +-------------------+
 <<<   7 syscalls  >>>   <<<   7 syscalls  >>>    <--- Attack surface
 +--------------------------------------------------+
@@ -169,13 +169,13 @@ To summarize, here's a side-by-side comparison of the models:
       gVisor                   NABLA
       ------                   -----
 
-+--------+              
++--------+
 |  p1a   |                                            APP
 +--------+              +---------+
 <<< 300 syscalls  >>>   |   p2a   |              <--- Guard Calls (2)
 +-------------------+   +-------------------+
 |      gVisor       |   |   nabla LibOS     |         USERSPACE KERNEL
-|   (code exec)     |   |                   |            
+|   (code exec)     |   |                   |
 +-------------------+   +-------------------+
 <<<  83 syscalls  >>>   <<<   7 syscalls  >>>    <--- Atk. surface (1)
 +--------------------------------------------------+
@@ -209,7 +209,7 @@ The vulnerability is detailed on STALKR's blog post ["Golang data races to break
 
 ## What's next?
 
-In conclusion, we've observed that gVisor and Nabla draw several similarities in the threat model, and yet they focus on different methods of providing security - maximize attack surface reduction (Nabla) vs guarding host syscalls and a safer implementation (gVisor). 
+In conclusion, we've observed that gVisor and Nabla draw several similarities in the threat model, and yet they focus on different methods of providing security - maximize attack surface reduction (Nabla) vs guarding host syscalls and a safer implementation (gVisor).
 We would like to find ways to quantify the two additional security ideas from gvisor (guarding host syscalls and safer implementations), to include in our isolation metric.
 
 As discussed, we think the guarding of host kernel calls provides security value add for Nabla, but we hypothesize that it may not add much to the security of the very limited attack surface. However, if it is possible to do this with little trade-off, it would be something that we would like to do in the future!


### PR DESCRIPTION
* Missing 'i' in 'Privilege'.
* 'p1a' listed twice in diagram.

Also remove trailing whitespace.

I'm not sure why this post is duplicated, but I've fixed both.